### PR TITLE
Add timeout for getLogger operation

### DIFF
--- a/com.sap.cloud.lm.sl.persistence/src/main/java/com/sap/cloud/lm/sl/persistence/services/FileLogCreator.java
+++ b/com.sap.cloud.lm.sl.persistence/src/main/java/com/sap/cloud/lm/sl/persistence/services/FileLogCreator.java
@@ -1,0 +1,101 @@
+package com.sap.cloud.lm.sl.persistence.services;
+
+import static java.text.MessageFormat.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.slf4j.LoggerFactory;
+
+import com.sap.cloud.lm.sl.common.SLException;
+import com.sap.cloud.lm.sl.persistence.message.Messages;
+
+
+public class FileLogCreator implements Callable<Logger> {
+
+	private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(FileLogCreator.class);
+	private static final String LOG_LAYOUT = "#2.0#%d{yyyy MM dd HH:mm:ss.SSS}#%d{XXX}#%p#%c#%n%X{MsgCode}#%X{CSNComponent}#%X{DCComponent}##%X{DSRCorrelationId}#%X{Application}#%C#%X{User}#%X{Session}#%X{Transaction}#%X{DSRRootContextId}#%X{DSRTransaction}#%X{DSRConnection}#%X{DSRCounter}#%t##%X{ResourceBundle}#%n%m#%n%n";
+
+	private String name;
+	private String logId;
+	private String prefix;
+	private String logDir;
+	private Level customLoggingLevel;
+	private PatternLayout customLayout;
+
+	public FileLogCreator(String name, String logId, String prefix, String logDir, Level customLoggingLevel,
+			PatternLayout customLayout) {
+		this.name = name;
+		this.logId = logId;
+		this.prefix = prefix;
+		this.logDir = logDir;
+		this.customLoggingLevel = customLoggingLevel;
+		this.customLayout = customLayout;
+	}
+
+	@Override
+	public Logger call() {
+		return getOrCreateLogger();
+	}
+
+	private Logger getOrCreateLogger() {
+		String loggerName = getLoggerName(prefix, logId, name);
+		Logger logger = LogManager.exists(loggerName);
+		if (logger == null) {
+			LOGGER.debug(format(Messages.CREATING_LOGGER, loggerName));
+			logger = createLogger(loggerName);
+		}
+		File logFile = ProcessLogsPersistenceService.getFile(logId, name, logDir);
+		if (logFile.exists()) {
+			recreateLogFile(logFile);
+		}
+		LOGGER.debug(format(Messages.CREATING_APPENDER, loggerName));
+		logger.addAppender(createAppender(logger.getLevel(), logFile));
+		return logger;
+	}
+
+	private void recreateLogFile(File logFile) {
+		logFile.delete();
+		try {
+			logFile.createNewFile();
+		} catch (IOException e) {
+			throw new SLException(e);
+		}
+	}
+
+	private Logger createLogger(String loggerName) {
+		Logger logger;
+		logger = Logger.getLogger(loggerName);
+		Level level = logger.getParent().getLevel();
+		if (customLoggingLevel != null) {
+			level = customLoggingLevel;
+		}
+		logger.setLevel(level);
+		return logger;
+	}
+
+	private Appender createAppender(Level level, File logFile) {
+		FileAppender appender = new FileAppender();
+		PatternLayout layout = new PatternLayout(LOG_LAYOUT);
+		if (customLayout != null) {
+			layout = customLayout;
+		}
+		appender.setLayout(layout);
+		appender.setFile(logFile.getAbsolutePath());
+		appender.setThreshold(level);
+		appender.setAppend(true);
+		appender.activateOptions();
+		return appender;
+	}
+
+	public static final String getLoggerName(String prefix, String logId, String name) {
+		return new StringBuilder(prefix).append(".").append(logId).append(".").append(name).toString();
+	}
+}

--- a/com.sap.cloud.lm.sl.persistence/src/main/java/com/sap/cloud/lm/sl/persistence/services/ProcessLoggerProviderFactory.java
+++ b/com.sap.cloud.lm.sl.persistence/src/main/java/com/sap/cloud/lm/sl/persistence/services/ProcessLoggerProviderFactory.java
@@ -2,246 +2,224 @@ package com.sap.cloud.lm.sl.persistence.services;
 
 import static java.text.MessageFormat.format;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.inject.Inject;
 
 import org.activiti.engine.delegate.DelegateExecution;
-import org.apache.log4j.Appender;
-import org.apache.log4j.FileAppender;
 import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.NOPLogger;
+import org.apache.log4j.varia.NullAppender;
 import org.slf4j.LoggerFactory;
 
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.persistence.message.Constants;
 import com.sap.cloud.lm.sl.persistence.message.Messages;
 
 public class ProcessLoggerProviderFactory {
 
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ProcessLoggerProviderFactory.class);
+	static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ProcessLoggerProviderFactory.class);
 
-    public static final String LOG_DIR = "logs";
-    private static final String LOG_LAYOUT = "#2.0#%d{yyyy MM dd HH:mm:ss.SSS}#%d{XXX}#%p#%c#%n%X{MsgCode}#%X{CSNComponent}#%X{DCComponent}##%X{DSRCorrelationId}#%X{Application}#%C#%X{User}#%X{Session}#%X{Transaction}#%X{DSRRootContextId}#%X{DSRTransaction}#%X{DSRConnection}#%X{DSRCounter}#%t##%X{ResourceBundle}#%n%m#%n%n";
+	public static String LOG_DIR = "logs";
 
-    // map between process id and logger
-    private final Map<String, Map<String, Logger>> LOGGERS = new HashMap<String, Map<String, Logger>>();
-    private final Map<String, ThreadLocalLogProvider> threadLocalProviderMap = new ConcurrentHashMap<String, ProcessLoggerProviderFactory.ThreadLocalLogProvider>();
+	// map between process id and logger
+	private final Map<String, Map<String, Logger>> LOGGERS = new HashMap<String, Map<String, Logger>>();
+	private final Map<String, ThreadLocalLogProvider> threadLocalProviderMap = new ConcurrentHashMap<String, ProcessLoggerProviderFactory.ThreadLocalLogProvider>();
 
-    private static ProcessLoggerProviderFactory instance;
+	private static ProcessLoggerProviderFactory instance;
 
-    @Inject
-    private ProcessLogsPersistenceService processLogsPersistenceService;
+	@Inject
+	private ProcessLogsPersistenceService processLogsPersistenceService;
 
-    public static ProcessLoggerProviderFactory getInstance() {
-        if (instance == null) {
-            instance = new ProcessLoggerProviderFactory();
-        }
-        return instance;
-    }
+	public static ProcessLoggerProviderFactory getInstance() {
+		if (instance == null) {
+			instance = new ProcessLoggerProviderFactory();
+		}
+		return instance;
+	}
 
-    public final ThreadLocalLogProvider getDefaultLoggerProvider() {
-        return getLoggerProvider(DEFAULT_NAME);
-    }
+	public final ThreadLocalLogProvider getDefaultLoggerProvider() {
+		return getLoggerProvider(DEFAULT_NAME);
+	}
 
-    public final ThreadLocalLogProvider getLoggerProvider(String name) {
-        ThreadLocalLogProvider result = threadLocalProviderMap.get(name);
-        if (result == null) {
-            result = new ThreadLocalLogProvider();
-            threadLocalProviderMap.put(name, result);
-        }
-        return result;
-    }
+	public final ThreadLocalLogProvider getLoggerProvider(String name) {
+		ThreadLocalLogProvider result = threadLocalProviderMap.get(name);
+		if (result == null) {
+			result = new ThreadLocalLogProvider();
+			threadLocalProviderMap.put(name, result);
+		}
+		return result;
+	}
 
-    public final void removeAll() {
-        for (ThreadLocal<Logger> threadLocal : threadLocalProviderMap.values()) {
-            threadLocal.remove();
-        }
-        threadLocalProviderMap.clear();
-    }
+	public final void removeAll() {
+		for (ThreadLocal<Logger> threadLocal : threadLocalProviderMap.values()) {
+			threadLocal.remove();
+		}
+		threadLocalProviderMap.clear();
+	}
 
-    public static final String DEFAULT_NAME = "MAIN_LOG";
+	public static final String DEFAULT_NAME = "MAIN_LOG";
 
-    public class ThreadLocalLogProvider extends ThreadLocal<Logger> {
+	public class ThreadLocalLogProvider extends ThreadLocal<Logger> {
 
-        private String prefix;
-        private String name;
-        private String processId;
-        private Level customLoggingLevel;
-        private PatternLayout customLayout;
-        private String logDir;
+		private String prefix;
+		private String name;
+		private String processId;
+		private Level customLoggingLevel;
+		private PatternLayout customLayout;
+		private String logDir;
 
-        private ThreadLocalLogProvider() {
-            super();
-        }
+		private ThreadLocalLogProvider() {
+			super();
+		}
 
-        public synchronized Logger getLogger(String processId, String prefix) {
-            this.processId = processId;
-            this.prefix = prefix;
-            this.name = DEFAULT_NAME;
-            this.logDir = LOG_DIR;
-            return get();
-        }
+		public synchronized Logger getLogger(String processId, String prefix) {
+			this.processId = processId;
+			this.prefix = prefix;
+			this.name = DEFAULT_NAME;
+			this.logDir = LOG_DIR;
+			return get();
+		}
 
-        public synchronized Logger getLogger(String processId, String prefix, String name) {
-            this.processId = processId;
-            this.prefix = prefix;
-            this.name = name;
-            this.logDir = LOG_DIR;
-            return get();
-        }
+		public synchronized Logger getLogger(String processId, String prefix, String name) {
+			this.processId = processId;
+			this.prefix = prefix;
+			this.name = name;
+			this.logDir = LOG_DIR;
+			return get();
+		}
 
-        public synchronized Logger getLogger(String processId, String prefix, String name, PatternLayout customLayout) {
-            this.processId = processId;
-            this.prefix = prefix;
-            this.customLayout = customLayout;
-            this.name = name;
-            this.logDir = LOG_DIR;
-            return get();
-        }
+		public synchronized Logger getLogger(String processId, String prefix, String name, PatternLayout customLayout) {
+			this.processId = processId;
+			this.prefix = prefix;
+			this.customLayout = customLayout;
+			this.name = name;
+			this.logDir = LOG_DIR;
+			return get();
+		}
 
-        public synchronized Logger getLogger(String processId, String prefix, Level customLoggingLevel, PatternLayout customLayout,
-            String customLogDir) {
-            this.processId = processId;
-            this.prefix = prefix;
-            this.customLoggingLevel = customLoggingLevel;
-            this.customLayout = customLayout;
-            this.name = DEFAULT_NAME;
-            this.logDir = customLogDir;
-            return get();
-        }
+		public synchronized Logger getLogger(String processId, String prefix, Level customLoggingLevel,
+				PatternLayout customLayout, String customLogDir) {
+			this.processId = processId;
+			this.prefix = prefix;
+			this.customLoggingLevel = customLoggingLevel;
+			this.customLayout = customLayout;
+			this.name = DEFAULT_NAME;
+			this.logDir = customLogDir;
+			return get();
+		}
 
-        @Override
-        protected Logger initialValue() {
-            Map<String, Logger> nameMap = LOGGERS.get(processId);
-            if (nameMap == null) {
-                nameMap = new HashMap<String, Logger>();
-                LOGGERS.put(processId, nameMap);
-            }
+		@Override
+		protected Logger initialValue() {
+			Map<String, Logger> nameMap = LOGGERS.get(processId);
+			if (nameMap == null) {
+				nameMap = new HashMap<String, Logger>();
+				LOGGERS.put(processId, nameMap);
+			}
 
-            Logger logger = nameMap.get(name);
-            if (logger == null) {
-                logger = getOrCreateLogger(processId, name);
-                nameMap.put(name, logger);
-            }
-            return logger;
-        }
+			Logger logger = nameMap.get(name);
+			if (logger == null) {
+				logger = getLoggerInSeparateThread();
+			}
+			if (logger.getLevel() != null) {
+				nameMap.put(name, logger);
+			}
+			return logger;
+		}
 
-        private Logger getOrCreateLogger(String logId, String name) {
-            String loggerName = getLoggerName(prefix, logId, name);
-            Logger logger = LogManager.exists(loggerName);
-            if (logger == null) {
-                LOGGER.debug(format(Messages.CREATING_LOGGER, loggerName));
-                logger = createLogger(loggerName);
-            }
-            File logFile = ProcessLogsPersistenceService.getFile(logId, name, logDir);
-            if (logFile.exists()) {
-                recreateLogFile(logFile);
-            }
-            LOGGER.debug(format(Messages.CREATING_APPENDER, loggerName));
-            logger.addAppender(createAppender(logger.getLevel(), logFile));
-            return logger;
-        }
+		private Logger getLoggerInSeparateThread() {
+			Logger logger;
+			ExecutorService executor = Executors.newSingleThreadExecutor();
+			try {
+				logger = tryToGetLogger(executor);
+				return logger;
+			} finally {
+				executor.shutdownNow();
+			}
+		}
 
-        private void recreateLogFile(File logFile) {
-            logFile.delete();
-            try {
-                logFile.createNewFile();
-            } catch (IOException e) {
-                throw new SLException(e);
-            }
-        }
+		Logger tryToGetLogger(ExecutorService executor) {
+			FileLogCreator logStorage = new FileLogCreator(name, processId, prefix, logDir, customLoggingLevel,
+					customLayout);
+			Future<Logger> logStorageTask = executor.submit(logStorage);
+			try {
+				return logStorageTask.get(30, TimeUnit.SECONDS);
+			} catch (InterruptedException | ExecutionException e) {
+				LOGGER.warn("Get logger operation was interrupted");
+			} catch (TimeoutException e) {
+				LOGGER.warn("Get logger operation has timed out");
+			}
+			Logger nullLogger = NOPLogger.getLogger("NOOP_LOGGER");
+			nullLogger.addAppender(new NullAppender());
+			return nullLogger;
+		}
 
-        private Logger createLogger(String loggerName) {
-            Logger logger;
-            logger = Logger.getLogger(loggerName);
-            Level level = logger.getParent().getLevel();
-            if (customLoggingLevel != null) {
-                level = customLoggingLevel;
-            }
-            logger.setLevel(level);
-            return logger;
-        }
+	}
 
-        private Appender createAppender(Level level, File logFile) {
-            FileAppender appender = new FileAppender();
-            PatternLayout layout = new PatternLayout(LOG_LAYOUT);
-            if (customLayout != null) {
-                layout = customLayout;
-            }
-            appender.setLayout(layout);
-            appender.setFile(logFile.getAbsolutePath());
-            appender.setThreshold(level);
-            appender.setAppend(true);
-            appender.activateOptions();
-            return appender;
-        }
+	public static String getProcessId(DelegateExecution context) {
+		return context.getProcessInstanceId();
+	}
 
-    }
+	private static String getSpaceId(DelegateExecution context) {
+		return (String) context.getVariable(Constants.VARIABLE_NAME_SPACE_ID);
+	}
 
-    public static final String getLoggerName(String prefix, String logId, String name) {
-        return new StringBuilder(prefix).append(".").append(logId).append(".").append(name).toString();
-    }
+	public void flush(DelegateExecution context, String logDir) throws IOException, FileStorageException {
+		String processId = getProcessId(context);
+		String spaceId = getSpaceId(context);
+		Map<String, Logger> nameMap = LOGGERS.remove(processId);
+		if (nameMap != null) {
+			LOGGER.debug(format(Messages.REMOVING_ALL_LOGGERS_FOR_PROCESS, processId, nameMap.keySet()));
+			for (String name : nameMap.keySet()) {
+				Logger logger = nameMap.get(name);
+				LOGGER.debug(format(Messages.REMOVING_ALL_APPENDERS_FROM_LOGGER, logger.getName()));
+				logger.removeAllAppenders();
+				saveLog(logDir, processId, spaceId, name);
+			}
+		}
+	}
 
-    public static String getProcessId(DelegateExecution context) {
-        return context.getProcessInstanceId();
-    }
+	public void append(DelegateExecution context, String logDir) throws IOException, FileStorageException {
+		String processId = getProcessId(context);
+		String spaceId = getSpaceId(context);
+		Map<String, Logger> nameMap = LOGGERS.remove(processId);
+		if (nameMap != null) {
+			LOGGER.debug(format(Messages.REMOVING_ALL_LOGGERS_FOR_PROCESS, processId, nameMap.keySet()));
+			for (String name : nameMap.keySet()) {
+				Logger logger = nameMap.get(name);
+				LOGGER.debug(format(Messages.REMOVING_ALL_APPENDERS_FROM_LOGGER, logger.getName()));
+				logger.removeAllAppenders();
+				appendLog(logDir, processId, spaceId, name);
+			}
+		}
+	}
 
-    private static String getSpaceId(DelegateExecution context) {
-        return (String) context.getVariable(Constants.VARIABLE_NAME_SPACE_ID);
-    }
+	private void saveLog(String logDir, String processId, String spaceId, String name)
+			throws IOException, FileStorageException {
+		if (spaceId == null) {
+			processLogsPersistenceService.saveLog(processId, name, logDir);
+		} else {
+			processLogsPersistenceService.saveLog(spaceId, processId, name, logDir);
+		}
+	}
 
-    public void flush(DelegateExecution context, String logDir) throws IOException, FileStorageException {
-        String processId = getProcessId(context);
-        String spaceId = getSpaceId(context);
-        Map<String, Logger> nameMap = LOGGERS.remove(processId);
-        if (nameMap != null) {
-            LOGGER.debug(format(Messages.REMOVING_ALL_LOGGERS_FOR_PROCESS, processId, nameMap.keySet()));
-            for (String name : nameMap.keySet()) {
-                Logger logger = nameMap.get(name);
-                LOGGER.debug(format(Messages.REMOVING_ALL_APPENDERS_FROM_LOGGER, logger.getName()));
-                logger.removeAllAppenders();
-                saveLog(logDir, processId, spaceId, name);
-            }
-        }
-    }
-
-
-    public void append(DelegateExecution context, String logDir) throws IOException, FileStorageException {
-        String processId = getProcessId(context);
-        String spaceId = getSpaceId(context);
-        Map<String, Logger> nameMap = LOGGERS.remove(processId);
-        if (nameMap != null) {
-            LOGGER.debug(format(Messages.REMOVING_ALL_LOGGERS_FOR_PROCESS, processId, nameMap.keySet()));
-            for (String name : nameMap.keySet()) {
-                Logger logger = nameMap.get(name);
-                LOGGER.debug(format(Messages.REMOVING_ALL_APPENDERS_FROM_LOGGER, logger.getName()));
-                logger.removeAllAppenders();
-                appendLog(logDir, processId, spaceId, name);
-            }
-        }
-    }
-
-    private void saveLog(String logDir, String processId, String spaceId, String name) throws IOException, FileStorageException {
-        if (spaceId == null) {
-            processLogsPersistenceService.saveLog(processId, name, logDir);
-        } else {
-            processLogsPersistenceService.saveLog(spaceId, processId, name, logDir);
-        }
-    }
-
-    private void appendLog(String logDir, String processId, String spaceId, String name) throws IOException, FileStorageException {
-        if (spaceId == null) {
-            processLogsPersistenceService.appendLog(processId, name, logDir);
-        } else {
-            processLogsPersistenceService.appendLog(spaceId, processId, name, logDir);
-        }
-    }
+	private void appendLog(String logDir, String processId, String spaceId, String name)
+			throws IOException, FileStorageException {
+		if (spaceId == null) {
+			processLogsPersistenceService.appendLog(processId, name, logDir);
+		} else {
+			processLogsPersistenceService.appendLog(spaceId, processId, name, logDir);
+		}
+	}
 
 }

--- a/com.sap.cloud.lm.sl.persistence/src/test/java/com/sap/cloud/lm/sl/persistence/services/ProcessLoggerProviderFactoryTest.java
+++ b/com.sap.cloud.lm.sl.persistence/src/test/java/com/sap/cloud/lm/sl/persistence/services/ProcessLoggerProviderFactoryTest.java
@@ -1,0 +1,182 @@
+package com.sap.cloud.lm.sl.persistence.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.activiti.engine.delegate.DelegateExecution;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sap.cloud.lm.sl.persistence.message.Constants;
+import com.sap.cloud.lm.sl.persistence.services.ProcessLoggerProviderFactory.ThreadLocalLogProvider;
+
+public class ProcessLoggerProviderFactoryTest {
+
+	private String logDir;
+
+	@Mock
+	private ProcessLogsPersistenceService processLogsPersistenceServiceMock;
+
+	@InjectMocks
+	private ProcessLoggerProviderFactory processLoggerProviderFactory = ProcessLoggerProviderFactory.getInstance();
+	private ThreadLocalLogProvider threadLocalProvider;
+
+	@Before
+	public void setUp() throws IOException {
+		MockitoAnnotations.initMocks(this);
+		threadLocalProvider = processLoggerProviderFactory.getLoggerProvider("test");
+		logDir = Files.createTempDirectory("testLogDir").toString();
+		ProcessLoggerProviderFactory.LOG_DIR = logDir;
+	}
+
+	@After
+	public void tearDown() throws IOException {
+		processLoggerProviderFactory.removeAll();
+		LogManager.shutdown();
+		if (Files.isDirectory(Paths.get(logDir))) {
+			deleteRecursivelyDirectory();
+		}
+	}
+
+	private void deleteRecursivelyDirectory() throws IOException {
+		Files.walkFileTree(Paths.get(logDir), new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.delete(file);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+				Files.delete(dir);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
+	@Test
+	public void testGetLogger() {
+		String processId = "1";
+		String prefix = "-";
+
+		Logger logger1 = threadLocalProvider.getLogger(processId, prefix);
+
+		assertTrue(logger1.getName().contains(processId));
+		assertTrue(logger1.getName().contains(prefix));
+	}
+
+	@Test
+	public void testGetLoggerWithCustomeName() {
+		String processId = "1";
+		String prefix = "-";
+		String name = "blabla";
+
+		Logger logger2 = threadLocalProvider.getLogger(processId, prefix, name);
+		assertTrue(logger2.getName().contains(name));
+	}
+
+	@Test
+	public void testGetLoggerWithCustomLoggingLevel() throws IOException {
+		String processId = "1";
+		String prefix = "-";
+		Level customLoggingLevel = Level.INFO;
+		PatternLayout customLayout = mock(PatternLayout.class);
+
+		Logger logger4 = threadLocalProvider.getLogger(processId, prefix, customLoggingLevel, customLayout, logDir);
+		assertEquals(logger4.getLevel(), customLoggingLevel);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testFileLogStorageThreadInterruption()
+			throws InterruptedException, ExecutionException, TimeoutException {
+		ExecutorService executorMock = mock(ExecutorService.class);
+		Future<Logger> futureTaskMock = mock(Future.class);
+		org.slf4j.Logger loggerMock = mock(org.slf4j.Logger.class);
+
+		when(executorMock.submit((java.util.concurrent.Callable<Logger>) any())).thenReturn(futureTaskMock);
+		doThrow(InterruptedException.class).when(futureTaskMock).get(anyLong(), any(TimeUnit.class));
+
+		ProcessLoggerProviderFactory.LOGGER = loggerMock;
+		threadLocalProvider.tryToGetLogger(executorMock);
+
+		verify(loggerMock).warn(anyString());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testFileLogStorageThreadTimeout() throws InterruptedException, ExecutionException, TimeoutException {
+		ExecutorService executorMock = mock(ExecutorService.class);
+		Future<Logger> futureTaskMock = mock(Future.class);
+		org.slf4j.Logger loggerMock = mock(org.slf4j.Logger.class);
+
+		when(executorMock.submit((java.util.concurrent.Callable<Logger>) any())).thenReturn(futureTaskMock);
+		doThrow(TimeoutException.class).when(futureTaskMock).get(anyLong(), any(TimeUnit.class));
+
+		ProcessLoggerProviderFactory.LOGGER = loggerMock;
+		threadLocalProvider.tryToGetLogger(executorMock);
+
+		verify(loggerMock).warn(anyString());
+	}
+
+	@Test
+	public void testFlush() throws IOException, FileStorageException {
+		org.slf4j.Logger loggerMock = mock(org.slf4j.Logger.class);
+		DelegateExecution contextMock = mock(DelegateExecution.class);
+		String processId = "11";
+
+		ProcessLoggerProviderFactory.LOGGER = loggerMock;
+		when(contextMock.getProcessInstanceId()).thenReturn(processId);
+		when(contextMock.getVariable(Constants.VARIABLE_NAME_SPACE_ID)).thenReturn(null);
+
+		threadLocalProvider.getLogger(processId, "-");
+		processLoggerProviderFactory.flush(contextMock, processId);
+		verify(loggerMock, atLeastOnce()).debug(anyString());
+		verify(processLogsPersistenceServiceMock).saveLog(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	public void testAppend() throws IOException, FileStorageException {
+		org.slf4j.Logger loggerMock = mock(org.slf4j.Logger.class);
+		DelegateExecution contextMock = mock(DelegateExecution.class);
+		String processId = "11";
+
+		ProcessLoggerProviderFactory.LOGGER = loggerMock;
+		when(contextMock.getProcessInstanceId()).thenReturn(processId);
+		when(contextMock.getVariable(Constants.VARIABLE_NAME_SPACE_ID)).thenReturn(null);
+
+		threadLocalProvider.getLogger(processId, "-");
+		processLoggerProviderFactory.append(contextMock, processId);
+		verify(loggerMock, atLeastOnce()).debug(anyString());
+		verify(processLogsPersistenceServiceMock).appendLog(anyString(), anyString(), anyString());
+	}
+}


### PR DESCRIPTION
In the event when the process logger could not open/persist a file,
it will time out and fall back to a NOPLogger, which does not
persist the process logs but allows for the execution to continue

JIRA: LMCROSSITXSADEPLOY-428